### PR TITLE
Fix state storage of view breaking due to string cast

### DIFF
--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -57,7 +57,9 @@ $this->vars['view_list'] = [
 # If view is queried from url, tell the session to use that view.
 # If not given, just use the session's previous view
 if(!is_array($_SESSION['view'])) $_SESSION['view'] = [];
-$view = (string)@$_GET['view'];
+$view = @$_GET['view'];
+if (isset($view)) $view = (string) $view;
+
 $_SESSION['view']['dashboard'] = $view ?? $_SESSION['view']['dashboard'] ?? "list";
 
 


### PR DESCRIPTION
4998b9b05db41030acfee311869bdef8448ec4ce broke session storage of view state, as the null coalesce operator stops falling through if you cast a `null` variable to `(string)`.