### PR TITLE
Implement post previews for more kinds of posts

### DIFF
--- a/pages/dashboard.php
+++ b/pages/dashboard.php
@@ -51,6 +51,10 @@ function getThumb($body) : array {
   }
   # TODO: Youtube:
   # https://stackoverflow.com/a/43001028/9238801
+  
+  if (is_url($body)) {
+    $out['src'] = 'link';
+  }
 
   return $out;
 }
@@ -115,10 +119,11 @@ case 'body':
   foreach ($posts as $post) {
     $body = $post['body'];
 
-    if (!is_url($body)) continue;
+    $hash = hash("md5", $body);
+    #if (!is_url($body)) continue;
 
     $post['thumb'] = getThumb($body);
-    $indexedPosts[$body][] = $post;
+    $indexedPosts[$hash][] = $post;
   }
 
   $this->vars['posts'] = $indexedPosts;

--- a/templates/thumbnail.html
+++ b/templates/thumbnail.html
@@ -34,6 +34,16 @@ these blocks.
   src="https://i.imgur.com/{{ thumb['slug'] }}t.jpg">
 {% endblock imgur %}
 
+{% block link %}
+<pre class="pre-scrollable" style="font-size: xx-small;">
+  <a href="{{ thumb['body'] }}">{{ thumb['slug'] }}</a>
+</pre>
+{% endblock link %}
+
+{% block text %}
+<pre class="pre-scrollable" style="font-size: xx-small;">{{ thumb['slug'] }}</pre>
+{% endblock text %}
+
 {#
 And so on for other providers, eg youtube, etc.
 #}

--- a/templates/thumbnail_dispatch.html
+++ b/templates/thumbnail_dispatch.html
@@ -2,6 +2,8 @@
   {{ block('gfy') }}
 {% elseif thumb['src'] == "imgur" %}
   {{ block('imgur') }}
+{% elseif thumb['src'] == "link" %}
+  {{ block('link') }}
 {% else %}
-
+  {{ block('text') }}
 {% endif %}


### PR DESCRIPTION
Resolves #46 , #5 . 

Text posts, and links (That don't resolve to thumbnails) are rendered in `<pre>` blocks (`.pre-scrollable`). 
Content view is indexed by hash of body.