### PR TITLE
Fix frontend selectors / jquery for feedback on new post submission

### DIFF
--- a/public_html/js/submit.js
+++ b/public_html/js/submit.js
@@ -64,13 +64,18 @@ postAppend = function() {
   );
 
   // Append this to the list
-  var p = $(this).prev().clone();
+  var p = $(this).parent().find("[id|='post']").first();
+  var p_new = p.clone();
 
-  p.prependTo($(this));
+  p_new.prependTo(p.parent());
+  
 
-  p.find("[name='subreddit']").text(payload['subreddit']);
-  p.find("[name='title']").text(payload['title']);
-  p.find("[name='when']").text(payload['whentime'] + payload['whendate']);
+  ['subreddit', 'title', 'whentime', 'whendate', 'whenzone'].forEach(
+    element => {
+      var field = p_new.find(`[name=${element}]`);
+      field.text(payload[element]);
+    }
+  )
 
   return false;
 }


### PR DESCRIPTION
I thought I had an issue for this, oh well. 

Some of this depends on #55 (The markup has been modified to breakout the whentime fields, which is what this selects on).

The previous selectors used to duplicate the last element were a bit brittle, and after someone added a horizontal rule to the content, it broke.