### PR TITLE
Improve whitespace use on mobile viewports, render errors on content-view

### DIFF
--- a/public_html/cronnit.css
+++ b/public_html/cronnit.css
@@ -45,7 +45,8 @@
  *    moving it right
  *   reduce the picker's size a bit
  * */
-@media (min-width: 768px) and (max-width: 991.98px) {
+@media (max-width: 575.98px),
+       (min-width: 768px) and (max-width: 991.98px) {
   .inline-date {
     padding-left: 0;
     z-index: -2;

--- a/public_html/cronnit.css
+++ b/public_html/cronnit.css
@@ -23,25 +23,19 @@
  * on Chrome
  * */
 
-/* Nothing for < md viewports, 
- * as these are handled by breakpoints
- * */
-
-/* From md viewports up, 
+/* For all viewports 
  * make the icon more like its real size
  * */
-@media (min-width: 768px) {
-  .inline-date::-webkit-calendar-picker-indicator {
-    bottom: 0;
-    cursor: pointer;
-    height: auto;
-    left: auto;
-    position: absolute;
-    right: 0;
-    top: 10%;
-    width: 1.2rem;
-    }
-}
+.inline-date::-webkit-calendar-picker-indicator {
+  bottom: 0;
+  cursor: pointer;
+  height: auto;
+  left: auto;
+  position: absolute;
+  right: 0;
+  top: 10%;
+  width: 1.2rem;
+  }
 
 /* At exactly the md viewport, space is tight
  * To display both the picker & the date, 

--- a/public_html/cronnit.css
+++ b/public_html/cronnit.css
@@ -37,15 +37,18 @@
   width: 1.2rem;
   }
 
-/* At exactly the md viewport, space is tight
- * To display both the picker & the date, 
+/* space is tight at:
+ *  * Viewports < "large phones" ( 425px), &
+ *  * exactly the md viewport, 
+ *
+ * * To display both the picker & the date, 
  *   remove the date's padding, 
  *     moving it left
  *   give the picker a negative right offset
  *    moving it right
  *   reduce the picker's size a bit
  * */
-@media (max-width: 575.98px),
+@media (max-width: 424.98px),
        (min-width: 768px) and (max-width: 991.98px) {
   .inline-date {
     padding-left: 0;

--- a/public_html/cronnit.css
+++ b/public_html/cronnit.css
@@ -37,9 +37,8 @@
   width: 1.2rem;
   }
 
-/* space is tight at:
- *  * Viewports < "large phones" ( 425px), &
- *  * exactly the md viewport, 
+/* space is tight at some viewports:
+ * (Described next to queries)
  *
  * * To display both the picker & the date, 
  *   remove the date's padding, 
@@ -48,8 +47,8 @@
  *    moving it right
  *   reduce the picker's size a bit
  * */
-@media (max-width: 424.98px),
-       (min-width: 768px) and (max-width: 991.98px) {
+@media (max-width: 424.98px), /* Smaller than "large phone */
+       (min-width: 768px) and (max-width: 991.98px) { /* Exactly bootstraps "md" */
   .inline-date {
     padding-left: 0;
     z-index: -2;

--- a/templates/error_icons.html
+++ b/templates/error_icons.html
@@ -1,0 +1,12 @@
+{# Error icons - embed me in twig when needed 
+ use the following syntax to ensure the context is correct:
+
+ {% embed "error_icons.html" with {post: post} only %}
+#}
+{% if post.error %}
+<i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
+{% elseif post.url is empty %}
+<i class="far fa-xs fa-clock text-muted"></i>
+{% else %}
+<i class="fa fa-xs fa-check text-muted"></i>
+{% endif %}

--- a/templates/posts-body.html
+++ b/templates/posts-body.html
@@ -29,13 +29,7 @@
             <div name="whenzone"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("T", timezone=post.whenzone) }}</div>
           </div>
           <div name="status" class="col-1 pl-1 px-md-auto text-center">
-            {% if post.error %}
-            <i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
-            {% elseif post.url is empty %}
-            <i class="far fa-xs fa-clock text-muted"></i>
-            {% else %}
-            <i class="fa fa-xs fa-check text-muted"></i>
-            {% endif %}
+            {% embed "error_icons.html" with {post: post} only %}{% endembed %}
           </div>
         </div>
       {% endfor %}

--- a/templates/posts-body.html
+++ b/templates/posts-body.html
@@ -28,6 +28,15 @@
             <div name="whentime"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("g:ia", timezone=post.whenzone) }}</div> 
             <div name="whenzone"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("T", timezone=post.whenzone) }}</div>
           </div>
+          <div name="status" class="col-1 pl-1 px-md-auto text-center">
+            {% if post.error %}
+            <i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
+            {% elseif post.url is empty %}
+            <i class="far fa-xs fa-clock text-muted"></i>
+            {% else %}
+            <i class="fa fa-xs fa-check text-muted"></i>
+            {% endif %}
+          </div>
         </div>
       {% endfor %}
 

--- a/templates/posts-body.html
+++ b/templates/posts-body.html
@@ -23,7 +23,7 @@
             <div name="subreddit" class="col-12 col-md-5 pl-2 card-text">{{ post.subreddit }}</div>
             <div name="title"     class="col-12 col-md-7 pl-2 card-text"><a href="/edit?id={{ post.id }}">{{ post.title }}</a></div>
           </div>
-          <div name="whens" class="col-4 col-md-6 row no-gutters">
+          <div name="whens" class="col-4 col-md-6 row no-gutters align-content-start">
             <div name="whendate"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("d/m/Y", timezone=post.whenzone) }}</div>
             <div name="whentime"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("g:ia", timezone=post.whenzone) }}</div> 
             <div name="whenzone"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("T", timezone=post.whenzone) }}</div>

--- a/templates/posts-body.html
+++ b/templates/posts-body.html
@@ -19,11 +19,11 @@
       {# <!-- Existing posts --> #}
       {% for post in instances %}
         <div class="row no-gutters row-striped" id="post-{{ post.id }}">
-          <div class="col-5 row no-gutters">
+          <div class="col-7 col-md-5 row no-gutters">
             <div name="subreddit" class="col-12 col-md-5 pl-2 card-text">{{ post.subreddit }}</div>
             <div name="title"     class="col-12 col-md-7 pl-2 card-text"><a href="/edit?id={{ post.id }}">{{ post.title }}</a></div>
           </div>
-          <div name="whens" class="col-6 row no-gutters">
+          <div name="whens" class="col-4 col-md-6 row no-gutters">
             <div name="whendate"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("d/m/Y", timezone=post.whenzone) }}</div>
             <div name="whentime"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("g:ia", timezone=post.whenzone) }}</div> 
             <div name="whenzone"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("T", timezone=post.whenzone) }}</div>
@@ -43,7 +43,7 @@
         {% set add_when_zone = add_id ~ "-whenzone" %}
         {% set add_submit = add_id ~ "-submit" %}
         <div class="form-row" id="{{ add_id }}">
-          <div name="info" class="col-5 row no-gutters">
+          <div name="info" class="col-7 col-md-5 row no-gutters">
           <div class="col-12 col-md-5">
             <label class="sr-only" for="{{ add_subreddit }}" >Subreddit</label>
             <input class="form-control form-control-sm" name="subreddit" type="text" id="{{ add_subreddit }}" placeholder="Subreddit" >
@@ -53,7 +53,7 @@
             <input class="form-control form-control-sm mh-100" name="title" type="text" id="{{ add_title }}" placeholder="Title" rows=1>
           </div>
           </div>
-          <div name="whens" class="col-6 row no-gutters">
+          <div name="whens" class="col-4 col-md-6 row no-gutters">
             <div class="col-12 col-md-4" >
               <label class="sr-only" for="{{ add_when_date }}" >Date To Submit</label>
               <input class="form-control form-control-sm inline-date" name="whendate" type="date" id="{{ add_when_date }}">

--- a/templates/posts-list.html
+++ b/templates/posts-list.html
@@ -12,13 +12,7 @@
 {% for post in posts %}
 <tr>
   <td>
-    {% if post.error %}
-    <i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
-    {% elseif post.url is empty %}
-    <i class="far fa-xs fa-clock text-muted"></i>
-    {% else %}
-    <i class="fa fa-xs fa-check text-muted"></i>
-    {% endif %}
+    {% embed "error_icons.html" with {post: post} only %}{% endembed %}
     <a href="/edit?id={{ post.id }}">{{ post.title }}</a>
     {% if post.ratelimit_count %}
     <span class="badge badge-warning">ratelimit</span>


### PR DESCRIPTION
Resolves #57 
Resolves #58 

CSS media queries now apply datepicker tweaks @ both: 
* the bootstrap `md` viewport, and 
* Viewports smaller than  `Mobile L` (`425px`) (Chrome's devtools calls it `Mobile L`.  

Additionally, minor reorg where I broke the error icon rendering into a separate template that's embedded by list-view / content view, for less repetition

Before:

![image](https://user-images.githubusercontent.com/39424834/94389352-0a538c80-0193-11eb-862e-f7e477eab8e3.png)
After:

![image](https://user-images.githubusercontent.com/39424834/94389412-2c4d0f00-0193-11eb-9098-0985570304ef.png)
