### PR TITLE
Improve process for bootstrapping dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ composer.lock
 *.log.err
 vendor/**
 public_html/google*.html
+
+# vagrant-env dotenv
+.env

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ and your reddit app's redirect uri.
       - Name it whatever.
       - For the redirect URI, choose the __exact same address and port as 
         you specified in `config.php`__, suffixed by `/authorize`.
-        - In our case, that should be:
-          `http://localhost:8080/authorize`.
+        - If you're bringing up the dev server using `vagrant`, that should be:
+          `http://cronnit.local/authorize`.
       - The about URL and description don't really matter.
   - The `client_id` should appear below your application name/to the right of 
     the icon on the [apps page](https://www.reddit.com/prefs/apps).
@@ -94,7 +94,25 @@ VirtualBox 6.1.6 r137129
 [See this ticket](https://www.virtualbox.org/ticket/19642#comment:6)
 
 - Install [`vagrant`](https://www.vagrantup.com/downloads) and
-[`VirtualBox` 6.1.6](https://www.virtualbox.org/wiki/Download_Old_Builds_6_1)*.
+[`VirtualBox` 6.1.6](https://www.virtualbox.org/wiki/Download_Old_Builds_6_1)
+- Install the `vagrant-hostmanager` & `vagrant-env` plugins
+  ```bash
+  vagrant plugin install vagrant-hostmanager 
+  vagrant plugin install vagrant-env
+  ```
+- Configure a `.env` configuration file:
+  ```bash
+  vim .env
+  ```
+
+  ```env
+  CRONNIT_CLIENT_ID=<client_id>
+  CRONNIT_CLIENT_SECRET=<client_secret>
+  CRONNIT_EMAIL=<email to use for letsencrypt>
+  LOCAL_MIRROR_SUBDOMAIN=<optional subdomain for ubuntu package repositories>
+  ```
+  - `<client_id>` & `<client_secret>` are those obtained from
+    your [reddit app](https://www.reddit.com/prefs/apps).
 - From within this project (where the `vagrantfile` lives):
   - install the vm with:
     ```bash
@@ -105,29 +123,9 @@ VirtualBox 6.1.6 r137129
     vagrant ssh
     ```
     You should find yourself logged in as `cronnit@ubuntu-focal`.
-  - Edit config.php:
-    ```bash
-    vim config.php
-    ```
-    Replace:
-    - `'url' => 'http://my.hostname.com'` with `'url' => 'http://localhost:8080'`
-    - `'client_id => 'xxxx`, `'client_secret' => 'xxxx'` with those obtained from
-      your [reddit app](https://www.reddit.com/prefs/apps).
 
-##### Running Server on Vagrant VM
+You should be able to access the server by navigating to `cronnit.local` in your browser.
 
-- To make the site you serve accessible by the host (from a browser on your main computer):
-  ```bash
-  $ lout &
-  ```
-  (This is simply an alias for some `socat` redirection)
-- To run the website:
-  ```bash
-  serve
-  ```
-  (This just navigates to `public_html`, and calls `php -S localhost:8080`).
-- To view the website, from a browser on your host, navigate to `http://localhost:8080` !
-- To refresh changes, you'll need to interrupt  `serve` (`Ctrl`+`c` ) and call it again `serve`.
 
 ## Donate
 

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,10 @@
 #
 # It's safe to re-run this script
 
-hostname="my.hostname.com"
-client_id="XXXX"
-client_secret="XXXX"
-email="myemail@gmail.com"
+hostname="${CRONNIT_HOSTNAME:-my.hostname.com}"
+client_id="${CRONNIT_CLIENT_ID:-XXXX}"
+client_secret="${CRONNIT_CLIENT_SECRET:-XXXX}"
+email="${CRONNIT_EMAIL:-myemail@gmail.com}"
 
 # Make sure we are running as root
 if [ $(whoami) != root ]; then

--- a/vagrant/change_mirror
+++ b/vagrant/change_mirror
@@ -13,4 +13,4 @@ sudo sed -i \
        /etc/apt/sources.list
 
 
-diff -y /etc/apt/sources.list /etc/apt/sources.list.bak
+diff -y /etc/apt/sources.list /etc/apt/sources.list.bak || true

--- a/vagrant/change_mirror
+++ b/vagrant/change_mirror
@@ -1,0 +1,16 @@
+echo "Changing sources.list to local mirror"
+
+if [ -z "$LOCAL_MIRROR_SUBDOMAIN" ]; then 
+  echo "No local mirror subdomain given, not changing sources.list"
+  exit 0
+fi
+
+cp /etc/apt/sources.list /etc/apt/sources.list.bak
+
+
+sudo sed -i \
+       -e "s#http://archive#http://${LOCAL_MIRROR_SUBDOMAIN}.archive#" \
+       /etc/apt/sources.list
+
+
+diff -y /etc/apt/sources.list /etc/apt/sources.list.bak

--- a/vagrantfile
+++ b/vagrantfile
@@ -1,25 +1,83 @@
+# Local IP Address
+IP = '192.168.33.11'
+
+# Specs
+CPUS = 2
+MEMORY = 1024 * 6
+
+
+def fail_with_message(msg)
+  fail Vagrant::Errors::VagrantError.new, msg
+end
+
 Vagrant.configure("2") do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/focal64"
 
+
+  if Vagrant.has_plugin? 'vagrant-env'
+    config.env.enable # enable vagrant-env (.env)
+  else
+    fail_with_message "vagrant-env missing, please install the plugin with this command:\nvagrant plugin install vagrant-env"
+  end
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine.
   # By connecting to localhost:8080 from the host, we can access the guest's 
   # webserver.
+  config.vm.hostname = 'cronnit.local'
 
-  config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :private_network, ip: IP, hostsupdater: 'skip'
+  # config.vm.network :forwarded_port, guest: 8080, host: 8080
   config.vm.network :forwarded_port, guest: 22, host: 5522
   
   # Forward x11 via ssh. 
   # Handy if you need to share a clipboard, convey viewport info, etc.
   config.ssh.forward_x11 = true
 
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = config.vm.hostname
+    vb.customize ['modifyvm', :id, '--cpus', CPUS]
+    vb.customize ['modifyvm', :id, '--memory', MEMORY]
+
+    # Fix for slow external network connections
+    vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+
+    # console file tty, is a must, wont boot without.
+    vb.customize ['modifyvm', :id, '--uartmode1', 'file', "%s-console.log" % vb.name]
+  end
+
+ # configure hostnames to access from localmachine
+  if Vagrant.has_plugin? 'vagrant-hostmanager'
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.aliases = [
+      'a.cronnit.local',
+    ]
+  else
+    fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager"
+  end
+
+
+  # Try to select a local apt package mirror
+  config.vm.provision "shell",
+    path: "vagrant/change_mirror",
+    env: {
+      "LOCAL_MIRROR_SUBDOMAIN" => ENV['LOCAL_MIRROR_SUBDOMAIN']
+    }
+
   # Run the standard install script, without ssl auth
 
   config.vm.provision "shell",
     path: "install.sh",
-    env: {"HTTP_ONLY" => "1"}
+    env: {
+      "HTTP_ONLY" => "1",
+      "CRONNIT_HOSTNAME"      => config.vm.hostname,
+      "CRONNIT_CLIENT_ID"     => ENV['CRONNIT_CLIENT_ID'],
+      "CRONNIT_CLIENT_SECRET" => ENV['CRONNIT_CLIENT_SECRET'],
+      "CRONNIT_EMAIL"         => ENV['CRONNIT_EMAIL']
+    }
   
   # Install some development dependencies
   config.vm.provision "shell",

--- a/vagrantfile
+++ b/vagrantfile
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 # Local IP Address
 IP = '192.168.33.11'
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -15,25 +15,18 @@ Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/focal64"
 
-
   if Vagrant.has_plugin? 'vagrant-env'
     config.env.enable # enable vagrant-env (.env)
   else
     fail_with_message "vagrant-env missing, please install the plugin with this command:\nvagrant plugin install vagrant-env"
   end
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine.
-  # By connecting to localhost:8080 from the host, we can access the guest's 
-  # webserver.
   config.vm.hostname = 'cronnit.local'
 
   config.vm.network :private_network, ip: IP, hostsupdater: 'skip'
-  # config.vm.network :forwarded_port, guest: 8080, host: 8080
-  config.vm.network :forwarded_port, guest: 22, host: 5522
   
   # Forward x11 via ssh. 
   # Handy if you need to share a clipboard, convey viewport info, etc.
-  config.ssh.forward_x11 = true
+  # config.ssh.forward_x11 = true
 
   config.vm.provider 'virtualbox' do |vb|
     vb.name = config.vm.hostname
@@ -44,8 +37,6 @@ Vagrant.configure("2") do |config|
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
 
-    # console file tty, is a must, wont boot without.
-    vb.customize ['modifyvm', :id, '--uartmode1', 'file', "%s-console.log" % vb.name]
   end
 
  # configure hostnames to access from localmachine


### PR DESCRIPTION
This was prompted by my own desire to make some contributions towards the project.

Since I contributed over a year ago, and provided instructions / some workflows on bootstrapping a vagrant dev-server, I've learnt a bit more about provisioning services, and found some tools that make this workflow less crufty.

This PR circumvents the need to use port forwarding & socket redirection when bringing up the dev VM, and lets a user connect to their dev-server instance from their browser using `http://cronnit.local`

Also, I added a script that lets users change the ubuntu apt mirror to something local.

I'm an Australian developer, & the default mirror tends to be US based, & the default connection to US package repository when provisioning VMs is a personal pain point of mine, as it really slows down the process.

For now, only adding a regional subdomain is supported, and this is optional.