### PR TITLE
Add error list + error icon rendering to content view

### DIFF
--- a/templates/error_icons.html
+++ b/templates/error_icons.html
@@ -1,0 +1,12 @@
+{# Error icons - embed me in twig when needed 
+ use the following syntax to ensure the context is correct:
+
+ {% embed "error_icons.html" with {post: post} only %}
+#}
+{% if post.error %}
+<i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
+{% elseif post.url is empty %}
+<i class="far fa-xs fa-clock text-muted"></i>
+{% else %}
+<i class="fa fa-xs fa-check text-muted"></i>
+{% endif %}

--- a/templates/posts-body.html
+++ b/templates/posts-body.html
@@ -28,6 +28,9 @@
             <div name="whentime"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("g:ia", timezone=post.whenzone) }}</div> 
             <div name="whenzone"  class="col-12 col-md-4 pl-2 card-text">{{ post.when | date("T", timezone=post.whenzone) }}</div>
           </div>
+          <div name="status" class="col-1 pl-1 px-md-auto text-center">
+            {% embed "error_icons.html" with {post: post} only %}{% endembed %}
+          </div>
         </div>
       {% endfor %}
 

--- a/templates/posts-list.html
+++ b/templates/posts-list.html
@@ -12,13 +12,7 @@
 {% for post in posts %}
 <tr>
   <td>
-    {% if post.error %}
-    <i class="fas fa-xs fa-exclamation-triangle text-danger"></i>
-    {% elseif post.url is empty %}
-    <i class="far fa-xs fa-clock text-muted"></i>
-    {% else %}
-    <i class="fa fa-xs fa-check text-muted"></i>
-    {% endif %}
+    {% embed "error_icons.html" with {post: post} only %}{% endembed %}
     <a href="/edit?id={{ post.id }}">{{ post.title }}</a>
     {% if post.ratelimit_count %}
     <span class="badge badge-warning">ratelimit</span>


### PR DESCRIPTION
Resolves #57

Squash of:
* Add error icons to body view
* Refactor error icon rendering into subtemplate for reuse between views

Based on #59 , but #59 tangled this topic ( #57 ) with some frontend-only markup tweaks, so I'm separating these into different PRs

See #59 for screenshots of what this looks like